### PR TITLE
chore(release): pulling release/1.3.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 1.3.0 (2024-11-06)
+
+
+### Features
+
+* upgraded customer.io SDK version to 3.5.1 ([#13](https://github.com/rudderlabs/rudder-integration-customerio-ios/issues/13)) ([540f800](https://github.com/rudderlabs/rudder-integration-customerio-ios/commit/540f800b3fdcc2739d4fde47233cdaf78221477c))
+
 ## 1.2.0 (2024-09-09)
 
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,100 +1,98 @@
 PODS:
-  - "AnalyticsSwiftCIO (1.5.13+cio.1)":
+  - "AnalyticsSwiftCIO (1.5.14+cio.1)":
     - JSONSafeEncoding (= 2.0.0)
     - Sovran (= 1.1.1)
-  - CustomerIO/DataPipelines (3.2.2):
-    - CustomerIODataPipelines (= 3.2.2)
-  - CustomerIO/MessagingInApp (3.2.2):
-    - CustomerIOMessagingInApp (= 3.2.2)
-  - CustomerIO/MessagingPushAPN (3.2.2):
-    - CustomerIOMessagingPushAPN (= 3.2.2)
-  - CustomerIO/MessagingPushFCM (3.2.2):
-    - CustomerIOMessagingPushFCM (= 3.2.2)
-  - CustomerIOCommon (3.2.2)
-  - CustomerIODataPipelines (3.2.2):
-    - "AnalyticsSwiftCIO (= 1.5.13+cio.1)"
-    - CustomerIOCommon (= 3.2.2)
-    - CustomerIOTrackingMigration (= 3.2.2)
-  - CustomerIOMessagingInApp (3.2.2):
-    - CustomerIOCommon (= 3.2.2)
-  - CustomerIOMessagingPush (3.2.2):
-    - CustomerIOCommon (= 3.2.2)
-  - CustomerIOMessagingPushAPN (3.2.2):
-    - CustomerIOMessagingPush (= 3.2.2)
-  - CustomerIOMessagingPushFCM (3.2.2):
-    - CustomerIOMessagingPush (= 3.2.2)
-    - FirebaseMessaging (< 11, >= 8.7.0)
-  - CustomerIOTrackingMigration (3.2.2):
-    - CustomerIOCommon (= 3.2.2)
+  - CustomerIO/DataPipelines (3.5.1):
+    - CustomerIODataPipelines (= 3.5.1)
+  - CustomerIO/MessagingInApp (3.5.1):
+    - CustomerIOMessagingInApp (= 3.5.1)
+  - CustomerIO/MessagingPushAPN (3.5.1):
+    - CustomerIOMessagingPushAPN (= 3.5.1)
+  - CustomerIO/MessagingPushFCM (3.5.1):
+    - CustomerIOMessagingPushFCM (= 3.5.1)
+  - CustomerIOCommon (3.5.1)
+  - CustomerIODataPipelines (3.5.1):
+    - "AnalyticsSwiftCIO (= 1.5.14+cio.1)"
+    - CustomerIOCommon (= 3.5.1)
+    - CustomerIOTrackingMigration (= 3.5.1)
+  - CustomerIOMessagingInApp (3.5.1):
+    - CustomerIOCommon (= 3.5.1)
+  - CustomerIOMessagingPush (3.5.1):
+    - CustomerIOCommon (= 3.5.1)
+  - CustomerIOMessagingPushAPN (3.5.1):
+    - CustomerIOMessagingPush (= 3.5.1)
+  - CustomerIOMessagingPushFCM (3.5.1):
+    - CustomerIOMessagingPush (= 3.5.1)
+    - FirebaseMessaging (< 12, >= 8.7.0)
+  - CustomerIOTrackingMigration (3.5.1):
+    - CustomerIOCommon (= 3.5.1)
   - FBSnapshotTestCase (2.1.4):
     - FBSnapshotTestCase/SwiftSupport (= 2.1.4)
   - FBSnapshotTestCase/Core (2.1.4)
   - FBSnapshotTestCase/SwiftSupport (2.1.4):
     - FBSnapshotTestCase/Core
-  - FirebaseCore (10.27.0):
-    - FirebaseCoreInternal (~> 10.0)
-    - GoogleUtilities/Environment (~> 7.12)
-    - GoogleUtilities/Logger (~> 7.12)
-  - FirebaseCoreInternal (10.27.0):
-    - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseInstallations (10.27.0):
-    - FirebaseCore (~> 10.0)
-    - GoogleUtilities/Environment (~> 7.8)
-    - GoogleUtilities/UserDefaults (~> 7.8)
-    - PromisesObjC (~> 2.1)
-  - FirebaseMessaging (10.27.0):
-    - FirebaseCore (~> 10.0)
-    - FirebaseInstallations (~> 10.0)
-    - GoogleDataTransport (~> 9.3)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
-    - GoogleUtilities/Environment (~> 7.8)
-    - GoogleUtilities/Reachability (~> 7.8)
-    - GoogleUtilities/UserDefaults (~> 7.8)
-    - nanopb (< 2.30911.0, >= 2.30908.0)
-  - GoogleDataTransport (9.4.1):
-    - GoogleUtilities/Environment (~> 7.7)
-    - nanopb (< 2.30911.0, >= 2.30908.0)
-    - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/AppDelegateSwizzler (7.13.3):
+  - FirebaseCore (11.4.2):
+    - FirebaseCoreInternal (< 12.0, >= 11.4.2)
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/Logger (~> 8.0)
+  - FirebaseCoreInternal (11.4.2):
+    - "GoogleUtilities/NSData+zlib (~> 8.0)"
+  - FirebaseInstallations (11.4.0):
+    - FirebaseCore (~> 11.0)
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
+    - PromisesObjC (~> 2.4)
+  - FirebaseMessaging (11.4.0):
+    - FirebaseCore (~> 11.0)
+    - FirebaseInstallations (~> 11.0)
+    - GoogleDataTransport (~> 10.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/Reachability (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
+    - nanopb (~> 3.30910.0)
+  - GoogleDataTransport (10.1.0):
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
+  - GoogleUtilities/AppDelegateSwizzler (8.0.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Environment (7.13.3):
+  - GoogleUtilities/Environment (8.0.2):
     - GoogleUtilities/Privacy
-    - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.13.3):
+  - GoogleUtilities/Logger (8.0.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Network (7.13.3):
+  - GoogleUtilities/Network (8.0.2):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.13.3)":
+  - "GoogleUtilities/NSData+zlib (8.0.2)":
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (7.13.3)
-  - GoogleUtilities/Reachability (7.13.3):
+  - GoogleUtilities/Privacy (8.0.2)
+  - GoogleUtilities/Reachability (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilities/UserDefaults (7.13.3):
+  - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - JSONSafeEncoding (2.0.0)
   - MetricsReporter (1.2.1):
     - RSCrashReporter (= 1.0.1)
     - RudderKit (= 1.4.0)
-  - nanopb (2.30910.0):
-    - nanopb/decode (= 2.30910.0)
-    - nanopb/encode (= 2.30910.0)
-  - nanopb/decode (2.30910.0)
-  - nanopb/encode (2.30910.0)
+  - nanopb (3.30910.0):
+    - nanopb/decode (= 3.30910.0)
+    - nanopb/encode (= 3.30910.0)
+  - nanopb/decode (3.30910.0)
+  - nanopb/encode (3.30910.0)
   - PromisesObjC (2.4.0)
   - RSCrashReporter (1.0.1)
   - Rudder (1.26.3):
     - MetricsReporter (= 1.2.1)
-  - Rudder-CustomerIO (1.0.0):
-    - CustomerIO/DataPipelines (~> 3.2.2)
+  - Rudder-CustomerIO (1.2.0):
+    - CustomerIO/DataPipelines (~> 3.5.1)
     - Rudder (~> 1.26)
   - RudderKit (1.4.0)
   - Sovran (1.1.1)
@@ -138,29 +136,29 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  AnalyticsSwiftCIO: 2a96166f72216a50b17f2516c7c2ec30e15b6223
-  CustomerIO: e5bc96b0a188b89d53613cb0c1ca542c209f5b1c
-  CustomerIOCommon: 93054e3e52840c8ceec5894dd32cf548b516619d
-  CustomerIODataPipelines: bbf1a5bab1437efcbffe05e94537624010a3c8a4
-  CustomerIOMessagingInApp: aa06c5509014bc9fcddff9f9c59ddc299d603174
-  CustomerIOMessagingPush: 7e069140407ca55832756def8065226f6cd63ab0
-  CustomerIOMessagingPushAPN: e92e7ad7b2d02262cb12d9ce4420a879f9330fd5
-  CustomerIOMessagingPushFCM: fa0a2a82e0960e8f452367595858bfb01a6a44f0
-  CustomerIOTrackingMigration: 9aa4104eaede9fdecc3e43ee499950dbbb2c9687
+  AnalyticsSwiftCIO: d03712b33e85baecc86f0d38a6d53c97f7bc5bd1
+  CustomerIO: 1f63de115e50d32b2d9a1938226c3b0590d9a13d
+  CustomerIOCommon: d8de2bca8339b3fc564bfd679afd92bcc1f01c1d
+  CustomerIODataPipelines: eda37083cca52eaa868e0465b8af573d37d12aec
+  CustomerIOMessagingInApp: d2b36bbf71994cd62557afd998a9bc81a500d166
+  CustomerIOMessagingPush: 085eae5a76bf67e22df4418b592c8fd6e82c4927
+  CustomerIOMessagingPushAPN: 9a2b88d8452dd99ecd36d6f1e0436a5d0bd2fa3f
+  CustomerIOMessagingPushFCM: 219e4af6497bd92d55f01608aded4c6a00d1f157
+  CustomerIOTrackingMigration: 13702d864a069f2298e29d22534eb67c292b5107
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  FirebaseCore: a2b95ae4ce7c83ceecfbbbe3b6f1cddc7415a808
-  FirebaseCoreInternal: 4b297a2d56063dbea2c1d0d04222d44a8d058862
-  FirebaseInstallations: 766dabca09fd94aef922538aaf144cc4a6fb6869
-  FirebaseMessaging: 585984d0a1df120617eb10b44cad8968b859815e
-  GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
-  GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
+  FirebaseCore: 6b32c57269bd999aab34354c3923d92a6e5f3f84
+  FirebaseCoreInternal: 35731192cab10797b88411be84940d2beb33a238
+  FirebaseInstallations: 6ef4a1c7eb2a61ee1f74727d7f6ce2e72acf1414
+  FirebaseMessaging: f8a160d99c2c2e5babbbcc90c4a3e15db036aee2
+  GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
+  GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   JSONSafeEncoding: 54722ebc4fe1482e3e60a8450e1287481e32dd8b
   MetricsReporter: 99596ee5003c69949ed2f50acc34aee83c42f843
-  nanopb: 438bc412db1928dac798aa6fd75726007be04262
+  nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
   Rudder: 23456f79749849870e18c45bd250d6e2229a7147
-  Rudder-CustomerIO: 3f92165eb87c4db57c205680371fd53688a10b7c
+  Rudder-CustomerIO: cfba35055f37edc74c616c9ff434e0a11b273bec
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
   Sovran: f8212bb3855042a24689a73ea0219ca5295235da
 

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["Rudder-CustomerIO"]),
     ],
     dependencies: [
-        .package(name: "Customer.io", url: "https://github.com/customerio/customerio-ios", .exact("3.2.2")),
+        .package(name: "Customer.io", url: "https://github.com/customerio/customerio-ios", .exact("3.5.1")),
         .package(name: "Rudder", url: "https://github.com/rudderlabs/rudder-sdk-ios", "1.29.0"..<"2.0.0")
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Questions? Please join our [Slack channel](https://resources.rudderstack.com/joi
 
 ## Integrating CustomerIO with the RudderStack iOS SDK
 
-> **_NOTE:_** `Rudder-CustomerIO` version `1.2.0` is compatible with the `CustomerIO/DataPipelines` version `3.2.2`. 
+> **_NOTE:_** `Rudder-CustomerIO` version `1.3.0` is compatible with the `CustomerIO/DataPipelines` version `3.2.2`. 
 
 1. Add [CustomerIO](https://customer.io/) as a destination in the [RudderStack dashboard](https://app.rudderstack.com/).
 
@@ -21,7 +21,7 @@ Questions? Please join our [Slack channel](https://resources.rudderstack.com/joi
 Add the following line to your Podfile and followed by `pod install`:
 
 ```ruby
-pod 'Rudder-CustomerIO', '~> 1.2.0'
+pod 'Rudder-CustomerIO', '~> 1.3.0'
 ```
 
 ### Swift Package Manager (SPM)

--- a/Rudder-CustomerIO.podspec
+++ b/Rudder-CustomerIO.podspec
@@ -6,7 +6,7 @@ rudder_sdk_version = '~> 1.26'
 deployment_target = '13.0'
 
 customerio_sdk_name = 'CustomerIO/DataPipelines'
-customerio_sdk_version = '~> 3.2.2'
+customerio_sdk_version = '~> 3.5.1'
 
 Pod::Spec.new do |s|
   s.name             = 'Rudder-CustomerIO'

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
:crown: *An automated PR*

   1.2.0 (2024-11-06)<br> * feat: upgraded customer.io SDK version to 3.5.1 ( 13) ([540f800](https://github.com/rudderlabs/rudder-integration-customerio-ios/commit/540f800)), closes [ 13](https://github.com/rudderlabs/rudder-integration-customerio-ios/issues/13)<br> * Merge pull request  11 from rudderlabs/release/1.2.0 ([bcfc4d5](https://github.com/rudderlabs/rudder-integration-customerio-ios/commit/bcfc4d5)), closes [ 11](https://github.com/rudderlabs/rudder-integration-customerio-ios/issues/11)