### PR TITLE
chore(release): pulling release/1.4.1 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 1.4.1 (2025-03-06)
+
+
+### Bug Fixes
+
+* set swift version to 6.0 in the podspec file ([53b65a2](https://github.com/rudderlabs/rudder-integration-customerio-ios/commit/53b65a2091fd7a261097e98d35d4176d91f292ad))
+
 ## 1.4.0 (2025-03-04)
 
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -31,19 +31,19 @@ PODS:
   - FBSnapshotTestCase/Core (2.1.4)
   - FBSnapshotTestCase/SwiftSupport (2.1.4):
     - FBSnapshotTestCase/Core
-  - FirebaseCore (11.8.1):
-    - FirebaseCoreInternal (~> 11.8.0)
+  - FirebaseCore (11.9.0):
+    - FirebaseCoreInternal (~> 11.9.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/Logger (~> 8.0)
-  - FirebaseCoreInternal (11.8.0):
+  - FirebaseCoreInternal (11.9.0):
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseInstallations (11.8.0):
-    - FirebaseCore (~> 11.8.0)
+  - FirebaseInstallations (11.9.0):
+    - FirebaseCore (~> 11.9.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
-  - FirebaseMessaging (11.8.0):
-    - FirebaseCore (~> 11.8.0)
+  - FirebaseMessaging (11.9.0):
+    - FirebaseCore (~> 11.9.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleDataTransport (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
@@ -91,7 +91,7 @@ PODS:
   - RSCrashReporter (1.0.1)
   - Rudder (1.31.0):
     - MetricsReporter (= 2.0.0)
-  - Rudder-CustomerIO (1.3.0):
+  - Rudder-CustomerIO (1.4.0):
     - CustomerIO/DataPipelines (~> 3.8.0)
     - Rudder (~> 1.26)
   - RudderKit (1.4.0)
@@ -146,10 +146,10 @@ SPEC CHECKSUMS:
   CustomerIOMessagingPushFCM: ff1b719ba6364398b70ac1aef3e45a7fd076d267
   CustomerIOTrackingMigration: 2b3a85bedca491ec66faeaf23d273672b144eae4
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  FirebaseCore: 99fe0c4b44a39f37d99e6404e02009d2db5d718d
-  FirebaseCoreInternal: df24ce5af28864660ecbd13596fc8dd3a8c34629
-  FirebaseInstallations: 6c963bd2a86aca0481eef4f48f5a4df783ae5917
-  FirebaseMessaging: 487b634ccdf6f7b7ff180fdcb2a9935490f764e8
+  FirebaseCore: 7cfcf7e8b33985c06478fd2b96e2f7101eb61a1c
+  FirebaseCoreInternal: 154779013b85b4b290fdba38414df475f42e3096
+  FirebaseInstallations: c76d4931a485fc0cc2dc1d62d3ed0369846ea4b8
+  FirebaseMessaging: 07e196b68580e68104df5c1c1b09ac26d04b24ea
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   JSONSafeEncoding: 54722ebc4fe1482e3e60a8450e1287481e32dd8b
@@ -158,7 +158,7 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
   Rudder: 04713668b0b7d46f214e6b7b46b60134849661aa
-  Rudder-CustomerIO: 4569beb4d7cb77ffcbfcd77235887446a985d99d
+  Rudder-CustomerIO: 80d1b840a5b1dbfccc9e2beebff6e3f5b585b8c8
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
   Sovran: f8212bb3855042a24689a73ea0219ca5295235da
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Questions? Please join our [Slack channel](https://resources.rudderstack.com/joi
 
 ## Integrating CustomerIO with the RudderStack iOS SDK
 
-> **_NOTE:_** `Rudder-CustomerIO` version `1.4.0` is compatible with the `CustomerIO/DataPipelines` version `3.2.2`. 
+> **_NOTE:_** `Rudder-CustomerIO` version `1.4.1` is compatible with the `CustomerIO/DataPipelines` version `3.2.2`. 
 
 1. Add [CustomerIO](https://customer.io/) as a destination in the [RudderStack dashboard](https://app.rudderstack.com/).
 
@@ -21,7 +21,7 @@ Questions? Please join our [Slack channel](https://resources.rudderstack.com/joi
 Add the following line to your Podfile and followed by `pod install`:
 
 ```ruby
-pod 'Rudder-CustomerIO', '~> 1.4.0'
+pod 'Rudder-CustomerIO', '~> 1.4.1'
 ```
 
 ### Swift Package Manager (SPM)

--- a/Rudder-CustomerIO.podspec
+++ b/Rudder-CustomerIO.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Rudder-CustomerIO/Classes/**/*'
   s.static_framework = true
   s.ios.deployment_target = deployment_target
+  s.swift_version = '6.0'
   
   if defined?($CustomerIOSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified CustomerIO SDK version '#{$CustomerIOSDKVersion}'"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
:crown: *An automated PR*

   1.4.0 (2025-03-06)<br> * fix: set swift version to 6.0 in the podspec file ([53b65a2](https://github.com/rudderlabs/rudder-integration-customerio-ios/commit/53b65a2))<br> * Merge pull request  16 from rudderlabs/release/1.4.0 ([de99db5](https://github.com/rudderlabs/rudder-integration-customerio-ios/commit/de99db5)), closes [ 16](https://github.com/rudderlabs/rudder-integration-customerio-ios/issues/16)

## Description

We need to add the swift_version in the Podspec file to solve this issue:
<img width="813" alt="image" src="https://github.com/user-attachments/assets/0750c9c7-d170-4e3a-aa94-26901d39a9bd" />

This issue happens when we try to perform pod install on the released pod.