### PR TITLE
chore(release): pulling release/1.4.1 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 1.4.1 (2025-03-06)
+
+
+### Bug Fixes
+
+* set swift version to 5.0 in the podspec file ([f34baa0](https://github.com/rudderlabs/rudder-integration-customerio-ios/commit/f34baa0234e1a17bd3f71282690e534437242ef9))
+
 ## 1.4.0 (2025-03-04)
 
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Questions? Please join our [Slack channel](https://resources.rudderstack.com/joi
 
 ## Integrating CustomerIO with the RudderStack iOS SDK
 
-> **_NOTE:_** `Rudder-CustomerIO` version `1.4.0` is compatible with the `CustomerIO/DataPipelines` version `3.2.2`. 
+> **_NOTE:_** `Rudder-CustomerIO` version `1.4.1` is compatible with the `CustomerIO/DataPipelines` version `3.2.2`. 
 
 1. Add [CustomerIO](https://customer.io/) as a destination in the [RudderStack dashboard](https://app.rudderstack.com/).
 
@@ -21,7 +21,7 @@ Questions? Please join our [Slack channel](https://resources.rudderstack.com/joi
 Add the following line to your Podfile and followed by `pod install`:
 
 ```ruby
-pod 'Rudder-CustomerIO', '~> 1.4.0'
+pod 'Rudder-CustomerIO', '~> 1.4.1'
 ```
 
 ### Swift Package Manager (SPM)

--- a/Rudder-CustomerIO.podspec
+++ b/Rudder-CustomerIO.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Rudder-CustomerIO/Classes/**/*'
   s.static_framework = true
   s.ios.deployment_target = deployment_target
+  s.swift_version = '5.0'
   
   if defined?($CustomerIOSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified CustomerIO SDK version '#{$CustomerIOSDKVersion}'"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
:crown: *An automated PR*

   1.4.0 (2025-03-06)<br> * fix: set swift version to 5.0 in the podspec file ([f34baa0](https://github.com/rudderlabs/rudder-integration-customerio-ios/commit/f34baa0))<br> * Merge pull request  16 from rudderlabs/release/1.4.0 ([de99db5](https://github.com/rudderlabs/rudder-integration-customerio-ios/commit/de99db5)), closes [ 16](https://github.com/rudderlabs/rudder-integration-customerio-ios/issues/16)

## Description

We need to add the swift_version in the Podspec file to solve this `pod installation` issue:
<img width="813" alt="image" src="https://github.com/user-attachments/assets/0750c9c7-d170-4e3a-aa94-26901d39a9bd" />

This issue happens when we try to perform pod install on the released pod.